### PR TITLE
Refactor the base page object

### DIFF
--- a/test/e2e/page-object/page-object.js
+++ b/test/e2e/page-object/page-object.js
@@ -1,90 +1,89 @@
 'use strict';
 
-var PageObject = function(properties, methods) {
-    var propertyDescriptor = {};
+var PageObject = function (properties, methods) {
+  var propertyDescriptor = {};
 
-    for (var property in properties) {
-        _addProperty(properties[property], property);
-    }
+  for (var property in properties) {
+    _addProperty(properties[property], property);
+  }
 
-    for (var method in methods) {
-        _addMethod(methods[method], method);
-    }
+  for (var method in methods) {
+    _addMethod(methods[method], method);
+  }
 
-    function _addProperty(getter, name) {
-        propertyDescriptor[name] = {
-            get: _expectNavigationComplete(getter)
-        };
-    }
+  function _addProperty(getter, name) {
+    propertyDescriptor[name] = {
+      get: _expectNavigationComplete(getter)
+    };
+  }
 
-    function _addMethod(handler, name) {
-        propertyDescriptor[name] = {
-            value: _waitForNavigation(handler)
-        };
-    }
+  function _addMethod(handler, name) {
+    propertyDescriptor[name] = {
+      value: _expectNavigationComplete(handler)
+    };
+  }
 
-    Object.defineProperties(this, propertyDescriptor);
+  Object.defineProperties(this, propertyDescriptor);
 };
 
 PageObject.prototype.startNavigation = _startNavigation;
 PageObject.prototype.completeNavigation = _completeNavigation;
-PageObject.prototype.navigation = _navigation;
+PageObject.prototype.navigate = _navigate;
 
 module.exports = PageObject;
 
 // Private declarations
 
-function _startNavigation(url) {
-    if (!url) {
-        throw 'Missing url parameter.';
-    }
+/**
+ * This method flags the start of the navigation phase.
+ * By navigation we mean the process of reaching a specific state of the app. This can be a simple
+ * navigation to a page or a more complex journey such as navigating to a page, pressing something
+ * to open a modal, doing something inside the modal etc.
+ * @method _startNavigation
+ */
+function _startNavigation() {
+  if (typeof this.$navigationComplete !== 'undefined') {
+    throw 'Navigation already started.';
+  }
 
-    if (this.$navigation) {
-        throw 'Navigation already started.';
-    }
+  this.$navigationComplete = false;
 
-    this.$navigationDeferrer = protractor.promise.defer();
-    this.$navigation = this.$navigationDeferrer.promise;
-    this.url = url;
-    this.$navigationComplete = false;
-
-    return browser.get(this.url);
+  return protractor.promise.fulfilled();
 }
 
+/**
+ * Marks the end of a navigation phase.
+ * Between the start of the navigation and the end we can go through multiple steps already
+ * mentioned in the startNavigation function.
+ * @method _completeNavigation
+ */
 function _completeNavigation() {
-    if (!this.$navigation) {
-        throw 'Navigation not started.';
-    }
-
-    this.$navigationComplete = true;
-    this.$navigationDeferrer.fulfill();
-}
-
-function _navigation() {
-  if (!this.$navigation) {
+  if (typeof this.$navigationComplete === 'undefined') {
     throw 'Navigation not started.';
   }
 
-  return this.$navigation;
+  this.$navigationComplete = true;
+
+  return protractor.promise.fulfilled();
+}
+
+/**
+ * This method must be implemented by the inheriting objects and inside it we will typically
+ * call startNavigation optionally followed by multiple steps and ending with a call to
+ * completeNavigation.
+ * @method _navigate
+ */
+function _navigate() {
+  throw 'Undefined method. Navigate method needs to be defined by the inheriting objects.';
 }
 
 function _expectNavigationComplete(next) {
-    return function () {
-        if (!this.$navigationComplete) {
-            throw 'Navigation is not complete! Make sure completeNavigation is called before querying the page.';
-        }
+  return function () {
+    if (!this.$navigationComplete) {
+      throw 'Navigation is not complete! Make sure completeNavigation is called before querying ' +
+        'the page.';
+    }
 
-        return next.apply(this, arguments);
-    };
-}
-
-function _waitForNavigation(next) {
-    return function () {
-        var self = this;
-        var args = arguments;
-
-        return this.$navigation.then(function () {
-            return next.apply(self, args);
-        });
-    };
+    return next.apply(this, arguments);
+  };
 }

--- a/test/e2e/page-object/preview-product.js
+++ b/test/e2e/page-object/preview-product.js
@@ -7,8 +7,10 @@ var productsListingUrl = '#/products-listing';
 var PreviewProductPage = function (id) {
   id = id.toString();
 
-  this.startNavigation(productsListingUrl)
+  this.startNavigation()
+    .then(browser.get.bind(browser, productsListingUrl))
     .then(_openProductEditModal.bind(this, id))
+    // .then(_someOtherAction)
     .then(this.completeNavigation.bind(this));
     // or with an arrow function: .then(() => (this.completeNavigation()));
 };

--- a/test/e2e/page-object/product-listing.js
+++ b/test/e2e/page-object/product-listing.js
@@ -5,7 +5,9 @@ var PageObject = require('./page-object');
 var productsListingUrl = '#/products-listing';
 
 var ProductListingPage = function () {
-  this.startNavigation(productsListingUrl)
+  this.startNavigation()
+    .then(browser.get.bind(browser, productsListingUrl))
+    // .then(_someOtherAction)
     .then(this.completeNavigation.bind(this));
 };
 


### PR DESCRIPTION
Made the base page object more flexible to allow the usage of whichever browser navigation we want to use. Currently it's tightly coupled to `browser.get`. The refactoring allows to do the browser navigation outside `startNavigation` function therefore allowing to opt for `browser.setLocation` or `browser.get` or not doing browser navigation at all.

Example:

``` js
  this.startNavigation()
    .then(browser.get.bind(browser, productsListingUrl))
    .then(_openProductEditModal.bind(this, id))
    // .then(_someOtherAction)
    .then(this.completeNavigation.bind(this));
```
